### PR TITLE
TM-7-log-file-for-invalid-files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 venv/
 .idea/
+
+log_error_files.txt

--- a/main.py
+++ b/main.py
@@ -22,12 +22,15 @@ def shuffle_file_paths(all_paths):
 
 def convert_files_to_audio_segments(shuffled_file_paths):
     shuffled_audio_segments = []
+    error_file_paths = []
     for file_path in shuffled_file_paths:
         audio_segment = to_audio_segment(file_path)
         if audio_segment:
             shuffled_audio_segments.append(audio_segment)
+        else:
+            error_file_paths.append(file_path)
 
-    return shuffled_audio_segments
+    return shuffled_audio_segments, error_file_paths
 
 
 def to_audio_segment(file_path):
@@ -38,8 +41,8 @@ def to_audio_segment(file_path):
         return None
     except CouldntDecodeError:
         return None
-    # TODO: In error cases, add file name to a logger file that has a list of files that couldn't be processed
-
+    except IndexError:
+        return None
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -47,3 +50,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     all_file_paths = get_all_file_paths(args.audio)
     shuffle_file_paths(all_file_paths)
+    shuffled_audio, error_files = convert_files_to_audio_segments(all_file_paths)
+    with open("log_error_files.txt", "w") as log:
+        for error_file in error_files:
+            log.write(error_file + '\n')

--- a/test_main.py
+++ b/test_main.py
@@ -22,20 +22,24 @@ class Test(TestCase):
 
     def test_convert_files_to_audio_segments_happy_path(self):
         all_audio_files = ["test_sound_files/Clubs/3_C.m4a", "test_sound_files/Spades/5_S.m4a", "test_sound_files/Hearts/5_H.m4a"]
-        shuffled_audio_segments = convert_files_to_audio_segments(all_audio_files)
-        self.assertTrue(len(shuffled_audio_segments) == 3)
+        shuffled_audio, error_files = convert_files_to_audio_segments(all_audio_files)
+        self.assertTrue(len(shuffled_audio) == 3)
+        self.assertTrue(len(error_files) == 0)
 
     def test_convert_files_to_audio_segments_non_existent_but_valid_sound_file(self):
-        non_existent_files = ["file_that_does_not_exist.wav"]
-        shuffled_audio_segments = convert_files_to_audio_segments(non_existent_files)
-        self.assertTrue(len(shuffled_audio_segments) == 0)
+        non_existent_sound_files = ["file_that_does_not_exist.wav"]
+        shuffled_audio, error_files = convert_files_to_audio_segments(non_existent_sound_files)
+        self.assertTrue(len(shuffled_audio) == 0)
+        self.assertTrue(error_files == non_existent_sound_files)
 
     def test_convert_files_to_audio_segments_non_existent_and_not_valid_sound_file(self):
-        non_existent_files = ["file_that_does_not_exist.txt"]
-        shuffled_audio_segments = convert_files_to_audio_segments(non_existent_files)
-        self.assertTrue(len(shuffled_audio_segments) == 0)
+        non_existent_non_sound_files = ["file_that_does_not_exist.txt"]
+        shuffled_audio, error_files = convert_files_to_audio_segments(non_existent_non_sound_files)
+        self.assertTrue(len(shuffled_audio) == 0)
+        self.assertTrue(error_files == non_existent_non_sound_files)
 
     def test_convert_files_to_audio_segments_non_existent_files(self):
         non_audio_files = ["test_sound_files/NonAudioFiles/non_audio_file.txt", "test_sound_files/NonAudioFiles/non_audio_file_no_ext"]
-        shuffled_audio_segments = convert_files_to_audio_segments(non_audio_files)
-        self.assertTrue(len(shuffled_audio_segments) == 0)
+        shuffled_audio, error_files = convert_files_to_audio_segments(non_audio_files)
+        self.assertTrue(len(shuffled_audio) == 0)
+        self.assertTrue(error_files == non_audio_files)


### PR DESCRIPTION
Modified convert_files_to_audio_segments to return a tuple of the shuffled audio segments, as well as those files that weren't able to be made into audio segments. In the main method, we open a log file and write these error file paths to it.