### PR TITLE
TM-8-get-absolute-path-instead

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,8 +11,8 @@ def get_all_file_paths(root_dir):
         root_dir = os.curdir
 
     all_paths = []
-    for (_, _, files) in os.walk(root_dir):
-        all_paths.extend(files)
+    for (dir_path, _, files) in os.walk(root_dir):
+        all_paths.extend(os.path.join(dir_path, file_name) for file_name in files)
     return all_paths
 
 

--- a/test_main.py
+++ b/test_main.py
@@ -6,7 +6,7 @@ from main import get_all_file_paths, convert_files_to_audio_segments
 class Test(TestCase):
     def test_get_all_file_paths_from_test_directory(self):
         all_sounds = get_all_file_paths('test_sound_files')
-        self.assertTrue(len(all_sounds) == 12)
+        self.assertTrue(all_sounds == ['test_sound_files\\Clubs\\3_C.m4a', 'test_sound_files\\Clubs\\7_C.m4a', 'test_sound_files\\Clubs\\K_C.m4a', 'test_sound_files\\Diamonds\\5_D.m4a', 'test_sound_files\\Hearts\\5_H.m4a', 'test_sound_files\\Hearts\\6_H.m4a', 'test_sound_files\\Hearts\\A_H.m4a', 'test_sound_files\\Hearts\\J_H.m4a', 'test_sound_files\\NonAudioFiles\\non_audio_file.txt', 'test_sound_files\\NonAudioFiles\\non_audio_file_no_ext', 'test_sound_files\\Spades\\5_S.m4a', 'test_sound_files\\Spades\\8_S.m4a'])
 
     def test_get_all_file_paths_from_current_directory(self):
         try:


### PR DESCRIPTION
Changed os.walk for loop so that we are able to get the full file path starting from the root directory instead of just the filenames.